### PR TITLE
Namespace support & Error reporting fix

### DIFF
--- a/expat.lua
+++ b/expat.lua
@@ -122,8 +122,8 @@ function parser.read(read, callbacks)
 			local data, size, more = read()
 			if C.XML_Parse(parser, data, size, more and 0 or 1) == 0 then
 				error(string.format('XML parser error at line %d, col %d: "%s"',
-						C.XML_GetCurrentLineNumber(parser),
-						C.XML_GetCurrentColumnNumber(parser),
+						tonumber(C.XML_GetCurrentLineNumber(parser)),
+						tonumber(C.XML_GetCurrentColumnNumber(parser)),
 						ffi.string(C.XML_ErrorString(C.XML_GetErrorCode(parser)))))
 			end
 		until not more


### PR DESCRIPTION
This PR comprises two patches. The first one is a little fix on XML parsing error reporting. Currently, trying to parse a XML which contains an error would result in something like:

`luajit: lua_libs/expat/expat.lua:104: lua_libs/expat/expat.lua:125: bad argument #2 to 'format' (number expected, got cdata)`

The second patch adds support for calling `XML_ParserCreateNS`, which solves namespaces during parsing. This is very useful e.g. for parsing SOAP envelopes, as client implementations vary wildly in the way they organize namespaces, as is demonstrated by the testcases below.

``` lua
local expat = require'expat'
local pp = require'pp'

function testcase(xmlsrc)
    local xmlsoap = expat.treeparse({
        namespacesep = ':',
        string = xmlsrc})
    print('tag = '..pp.format(xmlsoap
        .tags['http://schemas.xmlsoap.org/soap/envelope/:Envelope']
        .tags['http://schemas.xmlsoap.org/soap/envelope/:Body']
        .children[1]
        .tag))
    for k,v in pairs(xmlsoap
            .tags['http://schemas.xmlsoap.org/soap/envelope/:Envelope']
            .tags['http://schemas.xmlsoap.org/soap/envelope/:Body']
            .children[1]
            .tags) do
        print(k..' = '..pp.format(v.cdata))
    end
    print''
end

--[[Both testcases below should generate the same output:
tag = 'http://test.soap.service.luapower.com/:serviceA'
paramB = 'SOME STUFF'
paramC = '123'
paramA = nil
]]--

-- Envelope generated by Python Suds 0.4.1
testcase[[<?xml version="1.0" encoding="UTF-8"?>
    <SOAP-ENV:Envelope xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
            xmlns:ns0="http://schemas.xmlsoap.org/soap/encoding/"
            xmlns:ns1="http://test.soap.service.luapower.com/"
            xmlns:ns2="http://schemas.xmlsoap.org/soap/envelope/"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
            SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
        <SOAP-ENV:Header/>
        <ns2:Body>
            <ns1:serviceA>
                <paramA></paramA>
                <paramB>SOME STUFF</paramB>
                <paramC>123</paramC>
            </ns1:serviceA>
        </ns2:Body>
    </SOAP-ENV:Envelope>]]

-- Envelope generated by Apache CXF 2.7.1
testcase[[<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
        <soap:Body>
            <ns1:serviceA xmlns:ns1="http://test.soap.service.luapower.com/">
                <paramA></paramA>
                <paramB>SOME STUFF</paramB>
                <paramC>123</paramC>
            </ns1:serviceA>
        </soap:Body>
    </soap:Envelope>]]
```
