### PR TITLE
Security harden

### DIFF
--- a/expat.lua
+++ b/expat.lua
@@ -34,12 +34,17 @@ local cbsetters = {
 	'skipped',        C.XML_SetSkippedEntityHandler,          ffi.typeof'XML_SkippedEntityHandler',
 }
 
+local NULL = ffi.new'void*'
+local function str(ptr, size)
+	return ptr ~= NULL and ffi.string(ptr, size) or nil
+end
+
 local function decode_attrs(attrs) --char** {k1,v1,...,NULL}
 	local t = {}
 	local i = 0
 	while true do
 		if attrs[i] == nil or attrs[i+1] == nil then break end
-		t[ffi.string(attrs[i])] = ffi.string(attrs[i+1])
+		t[str(attrs[i])] = str(attrs[i+1])
 		i = i + 2
 	end
 	return t
@@ -47,44 +52,44 @@ end
 
 local pass_nothing = function(_) end
 local cbdecoders = {
-	element = function(_, name, model) return ffi.string(name), model end,
+	element = function(_, name, model) return str(name), model end,
 	attr_list = function(_, elem, name, type, dflt, is_required)
-		return ffi.string(elem), ffi.string(name), ffi.string(type), ffi.string(dflt), is_required ~= 0
+		return str(elem), str(name), str(type), str(dflt), is_required ~= 0
 	end,
 	xml = function(_, version, encoding, standalone)
-		return ffi.string(version), ffi.string(encoding), standalone ~= 0
+		return str(version), str(encoding), standalone ~= 0
 	end,
 	entity = function(_, name, is_param_entity, val, val_len, base, sysid, pubid, notation)
-		return ffi.string(name), is_param_entity ~= 0, ffi.string(val, val_len), ffi.string(base),
-					ffi.string(sysid), ffi.string(pubid), ffi.string(notation)
+		return str(name), is_param_entity ~= 0, str(val, val_len), str(base),
+					str(sysid), str(pubid), str(notation)
 	end,
-	start_tag = function(_, name, attrs) return ffi.string(name), decode_attrs(attrs) end,
-	end_tag = function(_, name) return ffi.string(name) end,
-	cdata = function(_, s, len) return ffi.string(s, len) end,
-	pi = function(_, target, data) return ffi.string(target), ffi.string(data) end,
-	comment = function(_, s) return ffi.string(s) end,
+	start_tag = function(_, name, attrs) return str(name), decode_attrs(attrs) end,
+	end_tag = function(_, name) return str(name) end,
+	cdata = function(_, s, len) return str(s, len) end,
+	pi = function(_, target, data) return str(target), str(data) end,
+	comment = function(_, s) return str(s) end,
 	start_cdata = pass_nothing,
 	end_cdata = pass_nothing,
-	default = function(_, s, len) return ffi.string(s, len) end,
-	default_expand = function(_, s, len) return ffi.string(s, len) end,
+	default = function(_, s, len) return str(s, len) end,
+	default_expand = function(_, s, len) return str(s, len) end,
 	start_doctype = function(_, name, sysid, pubid, has_internal_subset)
-		return ffi.string(name), ffi.string(sysid), ffi.string(pubid), has_internal_subset ~= 0
+		return str(name), str(sysid), str(pubid), has_internal_subset ~= 0
 	end,
 	end_doctype = pass_nothing,
 	unparsed = function(name, base, sysid, pubid, notation)
-		return ffi.string(name), ffi.string(base), ffi.string(sysid), ffi.string(pubid), ffi.string(notation)
+		return str(name), str(base), str(sysid), str(pubid), str(notation)
 	end,
 	notation = function(_, name, base, sysid, pubid)
-		return ffi.string(name), ffi.string(base), ffi.string(sysid), ffi.string(pubid)
+		return str(name), str(base), str(sysid), str(pubid)
 	end,
-	start_namespace = function(_, prefix, uri) return ffi.string(prefix), ffi.string(uri) end,
-	end_namespace = function(_, prefix) return ffi.string(prefix) end,
+	start_namespace = function(_, prefix, uri) return str(prefix), str(uri) end,
+	end_namespace = function(_, prefix) return str(prefix) end,
 	not_standalone = pass_nothing,
 	ref = function(parser, context, base, sysid, pubid)
-		return parser, ffi.string(context), ffi.string(base), ffi.string(sysid), ffi.string(pubid)
+		return parser, str(context), str(base), str(sysid), str(pubid)
 	end,
-	skipped = function(_, name, is_parameter_entity) return ffi.string(name), is_parameter_entity ~= 0 end,
-	unknown = function(_, name, info) return ffi.string(name), info end,
+	skipped = function(_, name, is_parameter_entity) return str(name), is_parameter_entity ~= 0 end,
+	unknown = function(_, name, info) return str(name), info end,
 }
 
 local parser = {}
@@ -125,7 +130,7 @@ function parser.read(read, callbacks, options)
 				error(string.format('XML parser error at line %d, col %d: "%s"',
 						tonumber(C.XML_GetCurrentLineNumber(parser)),
 						tonumber(C.XML_GetCurrentColumnNumber(parser)),
-						ffi.string(C.XML_ErrorString(C.XML_GetErrorCode(parser)))))
+						str(C.XML_ErrorString(C.XML_GetErrorCode(parser)))))
 			end
 		until not more
 	end)

--- a/expat.lua
+++ b/expat.lua
@@ -117,12 +117,18 @@ function parser.read(read, callbacks, options)
 			local k, setter, cbtype = cbsetters[i], cbsetters[i+1], cbsetters[i+2]
 			if callbacks[k] then
 				setter(parser, cb(cbtype, callbacks[k], cbdecoders[k]))
+			elseif k == 'entity' then
+				setter(parser, cb(cbtype,
+						function(parser) C.XML_StopParser(parser, false) end,
+						function(parser) return parser end))
 			end
 		end
 		if callbacks.unknown then
 			C.XML_SetUnknownEncodingHandler(parser,
 				cb('XML_UnknownEncodingHandler', callbacks.unknown, cbdecoders.unknown), nil)
 		end
+
+		C.XML_SetUserData(parser, parser)
 
 		repeat
 			local data, size, more = read()

--- a/expat_test.lua
+++ b/expat_test.lua
@@ -5,6 +5,56 @@ local callbacks = setmetatable({}, {__index = function(t,k) return function(...)
 expat.parse({path='media/svg/zorro.svg'}, callbacks)
 pp(expat.treeparse{path='media/svg/zorro.svg'})
 
+
+--[[Test for CVE-2013-0340 vulnerability
+
+According to http://www.openwall.com/lists/oss-security/2013/04/12/6 this is apparently not going
+to be fixed directly by expat, but only on an application per application level. We rather adopt
+a safe default inspired by apr_xml_parser, and abort parsing if entity declarations are present.
+Users who need entity declarations to work should override the callback.
+
+See http://svn.apache.org/viewvc/apr/apr/trunk/xml/apr_xml.c?r1=757729&r2=781403&pathrev=781403
+]]--
+assert(not pcall(function()
+pp(expat.treeparse{string=[[<?xml version="1.0"?>
+<!DOCTYPE billion [
+<!ELEMENT billion (#PCDATA)>
+<!ENTITY laugh0 "ha">
+<!ENTITY laugh1 "&laugh0;&laugh0;">
+<!ENTITY laugh2 "&laugh1;&laugh1;">
+<!ENTITY laugh3 "&laugh2;&laugh2;">
+<!ENTITY laugh4 "&laugh3;&laugh3;">
+<!ENTITY laugh5 "&laugh4;&laugh4;">
+<!ENTITY laugh6 "&laugh5;&laugh5;">
+<!ENTITY laugh7 "&laugh6;&laugh6;">
+<!ENTITY laugh8 "&laugh7;&laugh7;">
+<!ENTITY laugh9 "&laugh8;&laugh8;">
+<!ENTITY laugh10 "&laugh9;&laugh9;">
+<!ENTITY laugh11 "&laugh10;&laugh10;">
+<!ENTITY laugh12 "&laugh11;&laugh11;">
+<!ENTITY laugh13 "&laugh12;&laugh12;">
+<!ENTITY laugh14 "&laugh13;&laugh13;">
+<!ENTITY laugh15 "&laugh14;&laugh14;">
+<!ENTITY laugh16 "&laugh15;&laugh15;">
+<!ENTITY laugh17 "&laugh16;&laugh16;">
+<!ENTITY laugh18 "&laugh17;&laugh17;">
+<!ENTITY laugh19 "&laugh18;&laugh18;">
+<!ENTITY laugh20 "&laugh19;&laugh19;">
+<!ENTITY laugh21 "&laugh20;&laugh20;">
+<!ENTITY laugh22 "&laugh21;&laugh21;">
+<!ENTITY laugh23 "&laugh22;&laugh22;">
+<!ENTITY laugh24 "&laugh23;&laugh23;">
+<!ENTITY laugh25 "&laugh24;&laugh24;">
+<!ENTITY laugh26 "&laugh25;&laugh25;">
+<!ENTITY laugh27 "&laugh26;&laugh26;">
+<!ENTITY laugh28 "&laugh27;&laugh27;">
+<!ENTITY laugh29 "&laugh28;&laugh28;">
+<!ENTITY laugh30 "&laugh29;&laugh29;">
+]>
+<billion>&laugh30;</billion>]]})
+end))
+
+
 function soaptest(xmlsrc)
 	local xmlsoap = expat.treeparse({
 		namespacesep = '|',


### PR DESCRIPTION
This one is only a proposal, it needs some discussion:
- Please check if I did the test for NULL correctly. I tried to follow the guidelines at http://luapower.com/luajit-notes.html for keeping it compatible with stock Lua + luaffi, but I have only tested it with LuaJIT.
- Is the test for NULL needed for all strings? I don't believe so, but I did it for safety. What I really observed was a segmentation fault with `ffi.string` receiving NULL when trying to register a `entity` callback for tests. All of `base, sysid, pubid, notation` were NULL.
- CVE-2013-0340 is better explained in the comment above the corresponding test. In short, the idea was to provide library users a safe default, although it cuts out a valid part of the XML standard. Apache's apr_xml_parser does the same.
