### PR TITLE
Support for externally specifying encoding (e.g. from HTTP header)

### DIFF
--- a/expat.lua
+++ b/expat.lua
@@ -110,8 +110,8 @@ function parser.read(read, callbacks, options)
 	glue.fcall(function(finally)
 		finally(free_callbacks)
 
-		local parser = options.namespacesep and C.XML_ParserCreateNS(nil, options.namespacesep:byte())
-				or C.XML_ParserCreate(nil)
+		local parser = options.namespacesep and C.XML_ParserCreateNS(options.encoding, options.namespacesep:byte())
+				or C.XML_ParserCreate(options.encoding)
 		finally(function() C.XML_ParserFree(parser) end)
 
 		for i=1,#cbsetters,3 do


### PR DESCRIPTION
Allow the encoding to be provided using the options table. This is useful e.g. when parsing XML received through an HTTP request or response, where the `charset` parameter provided in the `Content-Type` header may (per the RFC) override the one specified in the `<?xml ?>` tag.
